### PR TITLE
Allowing for simpler deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Silhouettes Movie
 
+## Local Development
+
 Run the frontend dev server:
 
     yarn dev
@@ -9,3 +11,18 @@ Run the backend containers:
     cd server
     cp .env.sample .env
     docker-compose up -d
+
+## Deployment
+
+1. SSH into the server instance where you wish to deploy this app
+2. Clone the repo
+3. Make sure the domain or sub-domain you wish to serve this app on is pointed to the public ip of the server
+4. Set the `VIRTUAL_HOST` and `LETSENCRYPT_HOST` environment variables in the `docker-compose.svelte.yml` file
+5. Run ./deploy-containers.sh and wait for everything to build
+
+### Logs
+
+- Frontend (Svelte) app: `docker-compose -f docker-compose.svelte.yml logs -f --tail=200`
+- Backend: `docker-compose -f server/docker-compose.yml logs -f --tail=200`
+
+Both these commands will stream logs starting from 200 lines of most recent logs

--- a/deploy-containers.sh
+++ b/deploy-containers.sh
@@ -1,2 +1,4 @@
+cp server/.env.sample server/.env
+docker-compose -f server/docker-compose.yml run --rm app yarn install
 docker-compose -f server/docker-compose.yml up -d
 docker-compose -f docker-compose.svelte.yml up -d

--- a/deploy-containers.sh
+++ b/deploy-containers.sh
@@ -1,0 +1,2 @@
+docker-compose -f server/docker-compose.yml up -d
+docker-compose -f docker-compose.svelte.yml up -d

--- a/docker-compose.svelte.yml
+++ b/docker-compose.svelte.yml
@@ -28,6 +28,8 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     depends_on:
       - svelte
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   nginx-proxy-letsencrypt:
     image: jrcs/letsencrypt-nginx-proxy-companion

--- a/docker-compose.svelte.yml
+++ b/docker-compose.svelte.yml
@@ -1,0 +1,47 @@
+version: "3.9"
+
+services:
+  svelte:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/code
+    environment:
+      VIRTUAL_HOST: silhouettes.autonomoustech.ca
+      VIRTUAL_PORT: 3000
+      LETSENCRYPT_HOST: silhouettes.autonomoustech.ca
+
+  nginx-proxy:
+    container_name: nginx-proxy
+    build: docker/nginx
+    restart: always
+    ports:
+      - 443:443
+      - 80:80
+    volumes:
+      - certs:/etc/nginx/certs
+      - html:/usr/share/nginx/html
+      - vhost:/etc/nginx/vhost.d
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    depends_on:
+      - svelte
+
+  nginx-proxy-letsencrypt:
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    environment:
+      - DEFAULT_EMAIL=abdullah@autonomoustech.ca
+      - ACME_CA_URI=https://acme-staging-v02.api.letsencrypt.org/directory
+      - NGINX_PROXY_CONTAINER=nginx-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - certs:/etc/nginx/certs
+      - html:/usr/share/nginx/html
+      - vhost:/etc/nginx/vhost.d
+    depends_on:
+      - nginx-proxy
+
+volumes:
+  certs: null
+  html: null
+  vhost: null

--- a/docker-compose.svelte.yml
+++ b/docker-compose.svelte.yml
@@ -7,6 +7,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/code
+      - static_volume:/silhouettes/static
     environment:
       VIRTUAL_HOST: silhouettes.autonomoustech.ca
       VIRTUAL_PORT: 3000
@@ -20,6 +21,7 @@ services:
       - 443:443
       - 80:80
     volumes:
+      - static_volume:/silhouettes/static
       - certs:/etc/nginx/certs
       - html:/usr/share/nginx/html
       - vhost:/etc/nginx/vhost.d
@@ -31,7 +33,7 @@ services:
     image: jrcs/letsencrypt-nginx-proxy-companion
     environment:
       - DEFAULT_EMAIL=abdullah@autonomoustech.ca
-      - ACME_CA_URI=https://acme-staging-v02.api.letsencrypt.org/directory
+#      - ACME_CA_URI=https://acme-staging-v02.api.letsencrypt.org/directory
       - NGINX_PROXY_CONTAINER=nginx-proxy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -42,6 +44,7 @@ services:
       - nginx-proxy
 
 volumes:
-  certs: null
-  html: null
-  vhost: null
+  static_volume:
+  certs:
+  html:
+  vhost:

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM jwilder/nginx-proxy
+# COPY vhost.d/default /etc/nginx/vhost.d/default
+COPY custom.conf /etc/nginx/conf.d/custom.conf

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,3 +1,3 @@
 FROM jwilder/nginx-proxy
-# COPY vhost.d/default /etc/nginx/vhost.d/default
+COPY vhost.d/default /etc/nginx/vhost.d/default
 COPY custom.conf /etc/nginx/conf.d/custom.conf

--- a/docker/nginx/custom.conf
+++ b/docker/nginx/custom.conf
@@ -1,0 +1,1 @@
+client_max_body_size 1024M;

--- a/docker/nginx/vhost.d/default
+++ b/docker/nginx/vhost.d/default
@@ -1,0 +1,57 @@
+location /static {
+      alias /silhouettes/static/;
+    }
+    location /.well-known/ {
+      proxy_set_header Cookie $http_cookie;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_pass http://127.0.0.1:8091/proof/;
+    }
+    location ~ ^/(console|v1|v2|v1alpha1)/ {
+      proxy_set_header  Host $host;
+      proxy_set_header  X-Real-IP $remote_addr;
+      proxy_set_header  X-Forwarded-Proto https;
+      proxy_set_header  X-Forwarded-For $remote_addr;
+      proxy_set_header  X-Forwarded-Host $remote_addr;
+      proxy_pass http://127.0.0.1:8080;
+    }
+    #location / {
+    #  proxy_set_header  Host $host;
+    #  proxy_set_header  X-Real-IP $remote_addr;
+    #  proxy_set_header  X-Forwarded-Proto https;
+    #  proxy_set_header  X-Forwarded-For $remote_addr;
+    #  proxy_set_header  X-Forwarded-Host $remote_addr;
+    #  proxy_pass http://127.0.0.1:3000;
+    #}
+    location /api/ {
+      proxy_set_header  Host $host;
+      proxy_set_header  X-Real-IP $remote_addr;
+      proxy_set_header  X-Forwarded-Proto https;
+      proxy_set_header  X-Forwarded-For $remote_addr;
+      proxy_set_header  X-Forwarded-Host $remote_addr;
+      rewrite ^ $request_uri?;
+      rewrite ^/api/(.*) /$1 break;
+      return 400;
+      proxy_pass http://127.0.0.1:8091$uri$is_args;
+    } 
+    location /ws {
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_http_version 1.1;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $host;
+      rewrite ^/ws/(.*) /$1 break;
+      
+      proxy_pass http://127.0.0.1:9090;
+    }
+    location /file {
+      proxy_pass http://127.0.0.1:8091;
+    }
+    location /auth {
+      proxy_set_header  Host $host;
+      proxy_set_header  X-Real-IP $remote_addr;
+      proxy_set_header  X-Forwarded-Proto https;
+      proxy_set_header  X-Forwarded-For $remote_addr;
+      proxy_set_header  X-Forwarded-Host $remote_addr;
+      proxy_pass http://127.0.0.1:3400;
+    }

--- a/docker/nginx/vhost.d/default
+++ b/docker/nginx/vhost.d/default
@@ -1,57 +1,57 @@
 location /static {
-      alias /silhouettes/static/;
-    }
-    location /.well-known/ {
-      proxy_set_header Cookie $http_cookie;
-      proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
-      proxy_pass http://127.0.0.1:8091/proof/;
-    }
-    location ~ ^/(console|v1|v2|v1alpha1)/ {
-      proxy_set_header  Host $host;
-      proxy_set_header  X-Real-IP $remote_addr;
-      proxy_set_header  X-Forwarded-Proto https;
-      proxy_set_header  X-Forwarded-For $remote_addr;
-      proxy_set_header  X-Forwarded-Host $remote_addr;
-      proxy_pass http://127.0.0.1:8080;
-    }
-    #location / {
-    #  proxy_set_header  Host $host;
-    #  proxy_set_header  X-Real-IP $remote_addr;
-    #  proxy_set_header  X-Forwarded-Proto https;
-    #  proxy_set_header  X-Forwarded-For $remote_addr;
-    #  proxy_set_header  X-Forwarded-Host $remote_addr;
-    #  proxy_pass http://127.0.0.1:3000;
-    #}
-    location /api/ {
-      proxy_set_header  Host $host;
-      proxy_set_header  X-Real-IP $remote_addr;
-      proxy_set_header  X-Forwarded-Proto https;
-      proxy_set_header  X-Forwarded-For $remote_addr;
-      proxy_set_header  X-Forwarded-Host $remote_addr;
-      rewrite ^ $request_uri?;
-      rewrite ^/api/(.*) /$1 break;
-      return 400;
-      proxy_pass http://127.0.0.1:8091$uri$is_args;
-    } 
-    location /ws {
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
-      proxy_http_version 1.1;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $host;
-      rewrite ^/ws/(.*) /$1 break;
-      
-      proxy_pass http://127.0.0.1:9090;
-    }
-    location /file {
-      proxy_pass http://127.0.0.1:8091;
-    }
-    location /auth {
-      proxy_set_header  Host $host;
-      proxy_set_header  X-Real-IP $remote_addr;
-      proxy_set_header  X-Forwarded-Proto https;
-      proxy_set_header  X-Forwarded-For $remote_addr;
-      proxy_set_header  X-Forwarded-Host $remote_addr;
-      proxy_pass http://127.0.0.1:3400;
-    }
+  alias /silhouettes/static/;
+}
+location /.well-known/ {
+  proxy_set_header Cookie $http_cookie;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-For $remote_addr;
+  proxy_pass http://host.docker.internal:8091/proof/;
+}
+location ~ ^/(console|v1|v2|v1alpha1)/ {
+  proxy_set_header  Host $host;
+  proxy_set_header  X-Real-IP $remote_addr;
+  proxy_set_header  X-Forwarded-Proto https;
+  proxy_set_header  X-Forwarded-For $remote_addr;
+  proxy_set_header  X-Forwarded-Host $remote_addr;
+  proxy_pass http://host.docker.internal:8080;
+}
+#location / {
+#  proxy_set_header  Host $host;
+#  proxy_set_header  X-Real-IP $remote_addr;
+#  proxy_set_header  X-Forwarded-Proto https;
+#  proxy_set_header  X-Forwarded-For $remote_addr;
+#  proxy_set_header  X-Forwarded-Host $remote_addr;
+#  proxy_pass http://host.docker.internal:3000;
+#}
+location /api/ {
+  proxy_set_header  Host $host;
+  proxy_set_header  X-Real-IP $remote_addr;
+  proxy_set_header  X-Forwarded-Proto https;
+  proxy_set_header  X-Forwarded-For $remote_addr;
+  proxy_set_header  X-Forwarded-Host $remote_addr;
+  rewrite ^ $request_uri?;
+  rewrite ^/api/(.*) /$1 break;
+  return 400;
+  proxy_pass http://host.docker.internal:8091$uri$is_args;
+} 
+location /ws {
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+  proxy_http_version 1.1;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header Host $host;
+  rewrite ^/ws/(.*) /$1 break;
+  
+  proxy_pass http://host.docker.internal:9090;
+}
+location /file {
+  proxy_pass http://host.docker.internal:8091;
+}
+location /auth {
+  proxy_set_header  Host $host;
+  proxy_set_header  X-Real-IP $remote_addr;
+  proxy_set_header  X-Forwarded-Proto https;
+  proxy_set_header  X-Forwarded-For $remote_addr;
+  proxy_set_header  X-Forwarded-Host $remote_addr;
+  proxy_pass http://host.docker.internal:3400;
+}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     depends_on:
       - 'hasura'
     ports:
-      - '3400:3000'
+      - '3400:3400'
     environment:
       HOST: 0.0.0.0
       PORT: 3000

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       WEBHOOK_URL: '${WEBHOOK_URL}'
       WEBHOOK_SECRET: '${WEBHOOK_SECRET}'
-      HASURA_SECRET:  '${HASURA_GRAPHQL_ADMIN_SECRET}'
+      HASURA_SECRET: '${HASURA_GRAPHQL_ADMIN_SECRET}'
       COINOS_URL: '${COINOS_URL}'
       COINOS_TOKEN: '${COINOS_TOKEN}'
       HASURA_JWT: '${HASURA_GRAPHQL_JWT_SECRET}'
@@ -31,7 +31,10 @@ services:
       SMTP_SECURE: "true"
     volumes:
       - ./:/app
-    network_mode: host
+    # network_mode: host
+    ports:
+      - 8091:8091
+      - 9090:9090
   hasura:
     container_name: silhasura
     image: hasura/graphql-engine:v2.0.4.cli-migrations-v3
@@ -45,7 +48,7 @@ services:
       - ./metadata:/hasura-metadata
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:pgpassword@postgres:5432/postgres
-      HASURA_GRAPHQL_ADMIN_SECRET:  '${HASURA_GRAPHQL_ADMIN_SECRET}'
+      HASURA_GRAPHQL_ADMIN_SECRET: '${HASURA_GRAPHQL_ADMIN_SECRET}'
       HASURA_GRAPHQL_JWT_SECRET: '${HASURA_GRAPHQL_JWT_SECRET}'
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: "anonymous"
@@ -60,7 +63,7 @@ services:
       HOST: 0.0.0.0
       PORT: 3000
       HASURA_ENDPOINT: '${HASURA_ENDPOINT}'
-      HASURA_GRAPHQL_ADMIN_SECRET:  '${HASURA_GRAPHQL_ADMIN_SECRET}'
+      HASURA_GRAPHQL_ADMIN_SECRET: '${HASURA_GRAPHQL_ADMIN_SECRET}'
       JWT_ALGORITHM: '${JWT_ALGORITHM}'
       JWT_KEY: '${JWT_KEY}'
       AUTO_MIGRATE: "true"
@@ -90,13 +93,13 @@ services:
     environment:
       POSTGRES_PASSWORD: pgpassword
       POSTGRES_DB: postgres
-        #   litecoin:
-        #     image: asoltys/litecoin:latest
-        #     container_name: litecoin 
-        #     volumes:
-        #       - ./litecoin:/config
-        #     restart: unless-stopped
-        #     ports:
-        #       - '19443:19443'
-        #       - '19506:18506'
-        #       - '19507:18507'
+  # litecoin:
+  #   image: asoltys/litecoin:latest
+  #   container_name: litecoin 
+  #   volumes:
+  #     - ./litecoin:/config
+  #   restart: unless-stopped
+  #   ports:
+  #     - '19443:19443'
+  #     - '19506:18506'
+  #     - '19507:18507'

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     depends_on:
       - 'hasura'
     ports:
-      - '3400:3400'
+      - '3400:3000'
     environment:
       HOST: 0.0.0.0
       PORT: 3000

--- a/server/index.js
+++ b/server/index.js
@@ -55,7 +55,9 @@ app.get('/cookie', (req, reply) => {
 require('./auth');
 require('./mail');
 require('./payments');
-require('./litecoin');
+
+// commented out cause we don't have litecoin service
+// require('./litecoin');
 
 nfts = [];
 last = undefined;
@@ -139,11 +141,11 @@ register = async (asset) => {
 	let { users } = result.data;
 
 	let { ticket, type } = nfts.find((n) => n.asset === asset);
-  let { name, filename } = artworks[type];
+	let { name, filename } = artworks[type];
 
 	const contract = {
 		entity: { domain: 'silhouettesthemovie.com' },
-    filename,
+		filename,
 		issuer_pubkey: users[0].pubkey,
 		name,
 		precision: 0,
@@ -154,7 +156,7 @@ register = async (asset) => {
 	result = await registry
 		.post({
 			asset_id: asset,
-			contract,
+			contract
 		})
 		.json();
 
@@ -164,11 +166,11 @@ register = async (asset) => {
 app.get('/register/all', async (req, res) => {
 	nfts = await getNfts();
 
-  try {
-    for(let i = 0; i < nfts.length; i++) {
-      await new Promise((r) => setTimeout(r, 2000));
-      await register(nfts[i].asset);
-    } 
+	try {
+		for (let i = 0; i < nfts.length; i++) {
+			await new Promise((r) => setTimeout(r, 2000));
+			await register(nfts[i].asset);
+		}
 
 		res.send(true);
 	} catch (e) {

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "@asoltys/bitcoin-core": "^3.0.7",
     "buffer-reverse": "^1.0.1",
     "fastify": "^3.18.0",
+    "fastify-cookie": "^5.3.2",
     "fastify-static": "^4.2.2",
     "jsonwebtoken": "^8.5.1",
     "litecoinjs-lib": "https://github.com/asoltys/litecoinjs-lib",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -13,30 +13,6 @@
     semver "^5.1.0"
     standard-error "^1.1.0"
 
-"@asoltys/liquidjs-lib@^5.1.38":
-  version "5.1.38"
-  resolved "https://registry.yarnpkg.com/@asoltys/liquidjs-lib/-/liquidjs-lib-5.1.38.tgz#397e91a4ada53e5973b50727e13f529adacf42f4"
-  integrity sha512-hEP5GdUy5V0NYz7wnc+GLDGNQcpIx/KIfFFK96FiScG990UdRUvgJx/33o+MEmUyyh5zzcr2V7CWNtF8moSxnw==
-  dependencies:
-    "@asoltys/secp256k1-zkp" "^2.0.4"
-    axios "^0.21.1"
-    bech32 "^1.1.2"
-    bip174 vulpemventures/bip174.git
-    bip32 "^2.0.4"
-    bip66 "^1.1.0"
-    bitcoin-ops "^1.4.0"
-    bs58check "^2.0.0"
-    buffer-es6 "^4.9.3"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.3"
-    merkle-lib "^2.0.10"
-    pushdata-bitcoin "^1.0.1"
-    randombytes "^2.0.1"
-    tiny-secp256k1 "^1.1.1"
-    typeforce "^1.11.3"
-    varuint-bitcoin "^1.0.4"
-    wif "^2.0.1"
-
 "@asoltys/request@^2.88.2":
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/@asoltys/request/-/request-2.88.2.tgz#105184146ff8a2b18f9ac93835b5a16461c1e14d"
@@ -62,14 +38,6 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-"@asoltys/secp256k1-zkp@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@asoltys/secp256k1-zkp/-/secp256k1-zkp-2.0.4.tgz#a0b5fcabd92a089fdbb0e47750d3f43d66b24d94"
-  integrity sha512-oe4ZhZQNdtF49/bX/yJaB2kGu2hf7QXzaCFxlHA8lcU4uejH9NIQvy9lqHyLyRDT+xy4VVG2g/BGJPFgc8MywA==
-  dependencies:
-    "@types/node" "^13.9.2"
-    long "^4.0.0"
-
 "@fastify/ajv-compiler@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz#5ce80b1fc8bebffc8c5ba428d5e392d0f9ed10a1"
@@ -93,16 +61,6 @@
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
-
-"@types/node@11.11.6":
-  version "11.11.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
-  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
-
-"@types/node@^13.9.2":
-  version "13.13.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.48.tgz#46a3df718aed5217277f2395a682e055a487e341"
-  integrity sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==
 
 abbrev@1:
   version "1.1.1"
@@ -203,13 +161,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -228,11 +179,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-bech32@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
-  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
 bech32@^2.0.0:
   version "2.0.0"
@@ -261,11 +207,7 @@ bip174@^2.0.1:
   resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.0.1.tgz#39cf8ca99e50ce538fb762589832f4481d07c254"
   integrity sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ==
 
-bip174@vulpemventures/bip174.git:
-  version "1.0.3"
-  resolved "https://codeload.github.com/vulpemventures/bip174/tar.gz/b6d0ffe54e0dfa72e971b68372f89b25f7602502"
-
-bip32@^2.0.4, bip32@^2.0.6:
+bip32@^2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.6.tgz#6a81d9f98c4cd57d05150c60d8f9e75121635134"
   integrity sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==
@@ -277,16 +219,6 @@ bip32@^2.0.4, bip32@^2.0.6:
     tiny-secp256k1 "^1.1.3"
     typeforce "^1.11.5"
     wif "^2.0.6"
-
-bip39@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.3.tgz#4a8b79067d6ed2e74f9199ac994a2ab61b176760"
-  integrity sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==
-  dependencies:
-    "@types/node" "11.11.6"
-    create-hash "^1.1.0"
-    pbkdf2 "^3.0.9"
-    randombytes "^2.0.1"
 
 bip66@^1.1.0:
   version "1.1.5"
@@ -359,11 +291,6 @@ buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
-
-buffer-es6@^4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/buffer-es6/-/buffer-es6-4.9.3.tgz#f26347b82df76fd37e18bcb5288c4970cfd5c404"
-  integrity sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ=
 
 buffer-reverse@^1.0.1:
   version "1.0.1"
@@ -484,7 +411,12 @@ content-disposition@^0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-cookie@^0.4.0:
+cookie-signature@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.1.0.tgz#cc94974f91fb9a9c1bb485e95fc2b7f4b120aff2"
+  integrity sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==
+
+cookie@^0.4.0, cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
@@ -494,7 +426,7 @@ core-util-is@1.0.2:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
+create-hash@^1.1.0, create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
@@ -505,7 +437,7 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
     ripemd160 "^2.0.1"
     sha.js "^2.4.0"
 
-create-hmac@^1.1.3, create-hmac@^1.1.4, create-hmac@^1.1.7:
+create-hmac@^1.1.3, create-hmac@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
@@ -724,6 +656,15 @@ fast-safe-stringify@^2.0.7:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
+fastify-cookie@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/fastify-cookie/-/fastify-cookie-5.3.2.tgz#915d708d1391096febe1aa2a27559e72ce57b14f"
+  integrity sha512-7ZrRDOxlzO8dxgQSYd3yOd1AWRghpXTP/GxiBel44GVyRyPiYgHeLfqjcoyPNJYPYAEUpxi+6NHkc96Zl8yh9w==
+  dependencies:
+    cookie "^0.4.1"
+    cookie-signature "^1.1.0"
+    fastify-plugin "^3.0.0"
+
 fastify-error@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/fastify-error/-/fastify-error-0.3.1.tgz#8eb993e15e3cf57f0357fc452af9290f1c1278d2"
@@ -806,11 +747,6 @@ flatstr@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
   integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
-
-follow-redirects@^1.10.0:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
-  integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1263,11 +1199,6 @@ lodash@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -1461,17 +1392,6 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
-
-pbkdf2@^3.0.9:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
-  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
-  dependencies:
-    create-hash "^1.1.2"
-    create-hmac "^1.1.4"
-    ripemd160 "^2.0.1"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -1851,7 +1771,7 @@ tiny-lru@^7.0.0:
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
   integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
-tiny-secp256k1@^1.1.1, tiny-secp256k1@^1.1.3, tiny-secp256k1@^1.1.6:
+tiny-secp256k1@^1.1.3, tiny-secp256k1@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz#7e224d2bee8ab8283f284e40e6b4acb74ffe047c"
   integrity sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==


### PR DESCRIPTION
This PR separates the frontend and backend into separate compose files which can be executed through the `deploy-containers.sh` script. The README.md has also been updated with basic instructions.